### PR TITLE
Updated public-key endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,3 @@ jobs:
         ES_ID: ${{ secrets.ES_ID }}
         ES_SECRET: ${{ secrets.ES_SECRET }}
         ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
-        PUSH_NOTIF_PUBLIC_KEY: ${{ secrets.PUSH_NOTIF_PUBLIC_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
         ES_ID: ${{ secrets.ES_ID }}
         ES_SECRET: ${{ secrets.ES_SECRET }}
         ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
-        PUSH_NOTIF_PUBLIC_KEY: ${{ secrets.PUSH_NOTIF_PUBLIC_KEY }}
         COGNITO_USER_POOL_ARN: ${{ secrets.COGNITO_USER_POOL_ARN }}
     - name: serverless-deploy
       uses: kaskadi/action-slscli@master
@@ -43,5 +42,4 @@ jobs:
         ES_ID: ${{ secrets.ES_ID }}
         ES_SECRET: ${{ secrets.ES_SECRET }}
         ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
-        PUSH_NOTIF_PUBLIC_KEY: ${{ secrets.PUSH_NOTIF_PUBLIC_KEY }}
         COGNITO_USER_POOL_ARN: ${{ secrets.COGNITO_USER_POOL_ARN }}

--- a/.github/workflows/syntax-test.yml
+++ b/.github/workflows/syntax-test.yml
@@ -28,5 +28,4 @@ jobs:
         ES_ID: ${{ secrets.ES_ID }}
         ES_SECRET: ${{ secrets.ES_SECRET }}
         ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
-        PUSH_NOTIF_PUBLIC_KEY: ${{ secrets.PUSH_NOTIF_PUBLIC_KEY }}
         COGNITO_USER_POOL_ARN: ${{ secrets.COGNITO_USER_POOL_ARN }}

--- a/lambdas/deregister-sub/serverless.yml
+++ b/lambdas/deregister-sub/serverless.yml
@@ -5,10 +5,6 @@ layers:
 package:
   include:
     - lambdas/deregister-sub/deregister-sub.js
-environment:
-  ES_ID: ${env:ES_ID}
-  ES_SECRET: ${env:ES_SECRET}
-  ES_ENDPOINT: ${env:ES_ENDPOINT}
 events:
   - http:
       method: post

--- a/lambdas/public-key/get-public-key.js
+++ b/lambdas/public-key/get-public-key.js
@@ -1,11 +1,33 @@
 module.exports.handler = async (event) => {
+  return await getKeys().then(buildResponse)
+}
+
+function getKeys () {
+  const es = require('aws-es-client')({
+    id: process.env.ES_ID,
+    token: process.env.ES_SECRET,
+    url: process.env.ES_ENDPOINT
+  })
+  return es.search({
+    index: 'push-keys',
+    body: {
+      from: 0,
+      size: 5,
+      query: {
+        match: {
+          app: 'kaskadi'
+        }
+      }
+    }
+  }).then(res => res.body.hits.hits[0])
+}
+
+function buildResponse (keys) {
   return {
-    statusCode: 200,
+    statusCode: keys ? 200 : 404,
     headers: {
       'Access-Control-Allow-Origin': '*'
     },
-    body: JSON.stringify({
-      publicKey: process.env.PUSH_NOTIF_PUBLIC_KEY
-    })
+    body: keys ? JSON.stringify({ publicKey: keys._source.publicKey }) : JSON.stringify({ message: 'No public key found for this application...' })
   }
 }

--- a/lambdas/public-key/serverless.yml
+++ b/lambdas/public-key/serverless.yml
@@ -5,8 +5,6 @@ layers:
 package:
   include:
     - lambdas/public-key/get-public-key.js
-environment:
-  PUSH_NOTIF_PUBLIC_KEY: ${env:PUSH_NOTIF_PUBLIC_KEY}
 events:
   - http:
       method: get

--- a/lambdas/register-sub/serverless.yml
+++ b/lambdas/register-sub/serverless.yml
@@ -5,10 +5,6 @@ layers:
 package:
   include:
     - lambdas/register-sub/register-sub.js
-environment:
-  ES_ID: ${env:ES_ID}
-  ES_SECRET: ${env:ES_SECRET}
-  ES_ENDPOINT: ${env:ES_ENDPOINT}
 events:
   - http:
       method: post

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,6 +31,10 @@ provider:
     service: ${self:service.name}
     logical-unit: push
     type: http
+  environment:
+    ES_ID: ${env:ES_ID}
+    ES_SECRET: ${env:ES_SECRET}
+    ES_ENDPOINT: ${env:ES_ENDPOINT}
 functions:
   RegisterSub: ${file(./lambdas/register-sub/serverless.yml)}
   DeregisterSub: ${file(./lambdas/deregister-sub/serverless.yml)}


### PR DESCRIPTION
**Changes description**
Refactored `public-key` endpoint to fetch key in database instead of working with environment variable (to prevent issues when rotating keys without forcing a redeploy).

**Updated features**
- _`public-key` endpoint:_ updated logic to fetch public key from `ES`
- _environment variables:_ removed public key from environment variables & moved `ES` related environment variables to API level